### PR TITLE
Fix syntax error under non-Debian-based distros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,8 +51,8 @@ AC_SUBST(DISTRIB_ID)
 AC_SUBST(DISTRIB_RELEASE)
 DISTRIB_VERSION_PARTS=(${DISTRIB_RELEASE//./ })
 
-if test ${DISTRIB_ID} = Ubuntu; then
-if ((${DISTRIB_VERSION_PARTS[[0]]} >= 16)); then
+if test "${DISTRIB_ID}" = Ubuntu; then
+if (("${DISTRIB_VERSION_PARTS[[0]]}" >= 16)); then
 AC_SUBST(LXCPACKAGE, lxc1)
 else
 AC_SUBST(LXCPACKAGE, lxc)


### PR DESCRIPTION
The missing quote marks around variables that may be empty cause the shell to throw an error running `configure`.